### PR TITLE
Fix message displayed when failing to add a Patient

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -92,7 +92,7 @@ Format: `addPatient n/NAME p/PHONE_NUMBER e/EMAIL ic/NRIC a/ADDRESS [t/TAG]`  <b
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`addDoctor n/NAME p/PHONE_NUMBER e/EMAIL ic/NRIC a/ADDRESS [t/TAG]`
 
 * Adds the specified person to MediConnect.
-* Each person can be added only once.
+* Each person can be added only once and can be **either** a Patient or a Doctor.
 * Each person's NRIC must be distinct.
 
 Examples:

--- a/src/main/java/seedu/address/logic/commands/AddPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPatientCommand.java
@@ -13,7 +13,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Patient;
 
 /**
- * Adds a person to the address book.
+ * Adds a patient to MediConnect.
  */
 public class AddPatientCommand extends Command {
 
@@ -37,12 +37,12 @@ public class AddPatientCommand extends Command {
             + PREFIX_TAG + "owesMoney";
 
     public static final String MESSAGE_SUCCESS = "New patient added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This patient already exists in the patients' list";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the persons' list.";
 
     private final Patient toAdd;
 
     /**
-     * Creates an AddCommand to add the specified {@code Person}
+     * Creates an AddPatientCommand to add the specified {@code Patient}
      */
     public AddPatientCommand(Patient patient) {
         requireNonNull(patient);

--- a/src/main/java/seedu/address/model/person/Doctor.java
+++ b/src/main/java/seedu/address/model/person/Doctor.java
@@ -7,7 +7,7 @@ import seedu.address.model.appointment.Appointment;
 import seedu.address.model.tag.Tag;
 
 /**
- * Represents a Doctor in the address book.
+ * Represents a Doctor in Mediconnect.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Doctor extends Person {

--- a/src/main/java/seedu/address/model/person/Patient.java
+++ b/src/main/java/seedu/address/model/person/Patient.java
@@ -10,7 +10,7 @@ import seedu.address.model.prescription.Prescription;
 import seedu.address.model.tag.Tag;
 
 /**
- * Represents a Patient in the address book.
+ * Represents a Patient in MediConnect.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Patient extends Person {


### PR DESCRIPTION
The message displayed when the patient added by the user already exists in the list sometimes includes the wrong role for that person.

Let's update the error message.