### PR TITLE
Fix message displayed when failing to add a Doctor

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddDoctorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddDoctorCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Doctor;
 
 /**
- * Adds a person to the address book.
+ * Adds a doctor to MediConnect.
  */
 public class AddDoctorCommand extends Command {
 
@@ -33,12 +33,12 @@ public class AddDoctorCommand extends Command {
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 ";
 
     public static final String MESSAGE_SUCCESS = "New doctor added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the doctors' list";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the persons' list.";
 
     private final Doctor toAdd;
 
     /**
-     * Creates an AddCommand to add the specified {@code Person}
+     * Creates an AddDoctorCommand to add the specified {@code Doctor}
      */
     public AddDoctorCommand(Doctor doctor) {
         requireNonNull(doctor);


### PR DESCRIPTION
The message displayed when the doctor added by the user already exists in the list sometimes includes the wrong role for that person.

Let's update the error message.