### PR TITLE
Fix UG errors

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -56,12 +56,6 @@ _With MediConnect, managing your healthcare practice has never been easier._
 * Words in `UPPER_CASE` are the parameters to be supplied by the user.<br>
   e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe`.
 
-* Items in square brackets are optional.<br>
-  e.g `n/NAME [t/TAG]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
-
-* Items with `…`​ after them can be used multiple times including zero times.<br>
-  e.g. `[t/TAG]…​` can be used as ` ` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.
-
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
 
@@ -70,6 +64,13 @@ _With MediConnect, managing your healthcare practice has never been easier._
 
 * Parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
+
+* Items in square brackets are optional.<br>
+  e.g `n/NAME [t/TAG]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
+    * **All other items must be filled, following the restrictions in the table below.**
+
+* Items with `…`​ after them can be used multiple times including zero times.<br>
+  e.g. `[t/TAG]…​` can be used as ` ` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.
 
 </div>
 
@@ -125,7 +126,7 @@ Format `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [ic/NRIC] [a/ADDRESS] [t/TAG]…
 * Tags can be removed by typing t/ without specifying any tags after it.
 
 Examples:
-* `edit 9 n/John Smith` will edit the name of the 9th person listed to "Jon Smith".
+* `edit 9 n/John Smith` will edit the name of the 9th person listed to "John Smith".
 
 ![Edit](images/Edit.png)
 


### PR DESCRIPTION
The User Guide has some minor spelling mistakes and vague restrictions for the "Address" input values.

Let's add restrictions for "Address" and correct the spelling mistakes.